### PR TITLE
Support for flux initialized in parent folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@dev_desh/flux-cap",
+	"type": "module",
 	"version": "0.1.2",
 	"description": "Git-aware CLI context manager for ADHD developers",
 	"bin": {
@@ -16,7 +17,8 @@
 		"prepublishOnly": "bun run build",
 		"publish": "npm publish --access=public",
 		"local-install": "bun run build && npm link",
-		"local-uninstall": "npm unlink -g flux-cap"
+		"local-uninstall": "npm unlink -g flux-cap",
+		"local-reinstall": "bun run local-uninstall && bun run local-install"
 	},
 	"engines": {
 		"node": ">=18.0.0"

--- a/src/commands/dump.command.ts
+++ b/src/commands/dump.command.ts
@@ -1,16 +1,17 @@
 import { randomUUID } from "crypto";
 import type { BrainDump, FluxConfig } from "../types";
 import { FLUX_BRAIN_DUMP_PATH, FLUX_CONFIG_PATH } from "../utils/constants";
-import { createBrainDumpFileIfNotExists, getConfigFile, getCurrentBranch, getGitUncommittedChanges, getMonthString, getWorkingDir } from "../utils/";
+import { createBrainDumpFileIfNotExists, getConfigFile, getCurrentBranch, getFluxPath, getGitUncommittedChanges, getMonthString, getWorkingDir } from "../utils/";
 
 export async function brainDumpAddCommand(message: string[]) {
+	const fluxPath = await getFluxPath()
 	const fs = await import("fs");
 	console.log("Creating brain dump...");
 
 	const monthString = getMonthString();
-	await createBrainDumpFileIfNotExists(monthString);
+	await createBrainDumpFileIfNotExists(monthString, fluxPath);
 
-	const config = await getConfigFile();
+	const config = await getConfigFile(fluxPath);
 	const workingDir = await getWorkingDir(config)
 	const branch = getCurrentBranch(config)
 	const hasUncommittedChanges = getGitUncommittedChanges(config);
@@ -25,11 +26,11 @@ export async function brainDumpAddCommand(message: string[]) {
 	};
 
 
-	const data: { dumps: BrainDump[] } = JSON.parse(fs.readFileSync(`${FLUX_BRAIN_DUMP_PATH}/${monthString}.json`, 'utf8'));
+	const data: { dumps: BrainDump[] } = JSON.parse(fs.readFileSync(`${fluxPath}${FLUX_BRAIN_DUMP_PATH}/${monthString}.json`, 'utf8'));
 
 	config.sorted ? data.dumps.unshift(newDump) : data.dumps.push(newDump);
 
-	fs.writeFileSync(`${FLUX_BRAIN_DUMP_PATH}/${monthString}.json`, JSON.stringify(data, null, 2));
+	fs.writeFileSync(`${fluxPath}${FLUX_BRAIN_DUMP_PATH}/${monthString}.json`, JSON.stringify(data, null, 2));
 
 	// After writeFileSync, add:
 	console.log(`✅ Brain dump saved: "${message.join(' ')}"`);

--- a/src/commands/init.command.ts
+++ b/src/commands/init.command.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { FLUX_BRAIN_DUMP_PATH, FLUX_CONFIG_PATH, FLUX_DEFAULT_CONFIG, FLUX_FOLDER_PATH, FLUX_SESSION_PATH } from "../utils/constants";
-import { createIfNotExists } from "../utils/";
+import { createIfNotExists, getFluxPath } from "../utils/";
 import inquirer from "inquirer";
 
 export async function initFluxCommand() {
@@ -90,6 +90,7 @@ export async function initFluxCommand() {
 
 export const resetFluxCommand = async () => {
 	console.log("Resetting Flux Capacitor...");
+	const fluxPath = await getFluxPath() + FLUX_FOLDER_PATH
 
 	const { confirmed } = await inquirer.prompt([{
 		type: 'confirm',
@@ -104,8 +105,8 @@ export const resetFluxCommand = async () => {
 	}
 
 	try {
-		if (fs.existsSync(FLUX_FOLDER_PATH)) {
-			fs.rmSync(FLUX_FOLDER_PATH, { recursive: true, force: true });
+		if (fs.existsSync(fluxPath)) {
+			fs.rmSync(fluxPath, { recursive: true, force: true });
 			console.log("Removed .flux directory and all its contents.");
 		}
 		else {

--- a/src/commands/search.command.ts
+++ b/src/commands/search.command.ts
@@ -1,17 +1,17 @@
 import Fuse from "fuse.js"
-import { FLUX_BRAIN_DUMP_PATH, getAllBrainDumpFilePaths, getConfigFile, getMonthString, searchResultFormat } from "../utils";
+import { FLUX_BRAIN_DUMP_PATH, getAllBrainDumpFilePaths, getConfigFile, getFluxPath, getMonthString, searchResultFormat } from "../utils";
 import { createFuseInstance } from "../utils/fuse.instance";
 import type { BrainDump } from "../types";
 import fs from "fs";
 
 export async function searchBrainDumpCommand(query: string[]) {
 	console.log("Searching all brain dumps...");
-
-	const config = await getConfigFile();
+	const fluxPath = await getFluxPath()
+	const config = await getConfigFile(fluxPath);
 	const monthString = getMonthString();
 
 	let searchResults = []
-	const allFilePaths = await getAllBrainDumpFilePaths();
+	const allFilePaths = await getAllBrainDumpFilePaths(fluxPath);
 
 	for await (const filePath of allFilePaths) {
 		const fileData: { dumps: BrainDump[] } = JSON.parse(fs.readFileSync(filePath, 'utf8'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { searchBrainDumpCommand } from "./commands/search.command";
 import { configCommand } from "./commands/config.command";
 import { helpOption } from "./commands/flux.option";
 import packageJson from "../package.json"
+import { getFluxPath } from "./utils";
 const program = new Command()
 
 program.name(`flux`).description('Git-aware CLI context manager for ADHD developers').version(packageJson.version);
@@ -31,5 +32,9 @@ program.command('search [query...]')
 program.command('config <fields...>')
 	.description('Update configuration fields. Example: flux config search.limit 10')
 	.action(configCommand)
+
+program.command("test").action(async () => {
+	console.log(`Path is - ${await getFluxPath()}`)
+})
 
 program.parse(process.argv);


### PR DESCRIPTION
Introduce getFluxPath() to locate the project root containing .flux. Pass fluxPath into utilities so config and brain-dump file IO uses it. Update init/reset/search/dump commands to use the discovered path. Add a test command to print the path.
Set package type to module and add a local-reinstall script.