### PR TITLE
[patch] changesets fix

### DIFF
--- a/.github/workflows/changeset-bot.yml
+++ b/.github/workflows/changeset-bot.yml
@@ -79,78 +79,84 @@ jobs:
         id: generate-changeset
         uses: actions/github-script@v7
         with:
-              script: |
-                  const prTitle = `${{ steps.pr-info.outputs.pr_title }}`;
-                  const prBody = `${{ steps.pr-info.outputs.pr_body }}`;
-                  const commits = `${{ steps.pr-info.outputs.commits }}`;
+          script: |
+            const prTitle = `${{ steps.pr-info.outputs.pr_title }}`;
+            const prBody = `${{ steps.pr-info.outputs.pr_body }}`;
+            const commits = `${{ steps.pr-info.outputs.commits }}`;
 
-                  // Get PR labels for manual override
-                  const pr = context.payload.pull_request;
-                  const labels = pr.labels.map(label => label.name.toLowerCase());
+            // Get PR labels for manual override
+            const pr = context.payload.pull_request;
+            const labels = pr.labels.map(label => label.name.toLowerCase());
 
-                  let versionType = 'patch'; // Conservative default
-                  let description = prTitle;
+            let versionType = 'patch'; // Conservative default
+            let description = prTitle;
+            let detectionMethod = 'automatic';
 
-                  // Manual override via labels (highest priority)
-                  if (labels.includes('major') || labels.includes('breaking')) {
-                    versionType = 'major';
-                  } else if (labels.includes('minor') || labels.includes('feature')) {
-                    versionType = 'minor';
-                  } else if (labels.includes('patch') || labels.includes('bugfix')) {
-                    versionType = 'patch';
-                  } else {
-                    // Manual override via PR title syntax: [major], [minor], [patch]
-                    const titleMatch = prTitle.match(/^\[(major|minor|patch)\]/i);
-                    if (titleMatch) {
-                      versionType = titleMatch[1].toLowerCase();
-                      description = prTitle.replace(/^\[(major|minor|patch)\]\s*/i, '');
-                    } else {
-                      // Automatic detection (much more conservative)
-                      const combined = (prTitle + ' ' + prBody + ' ' + commits).toLowerCase();
+            // Manual override via labels (highest priority)
+            if (labels.includes('major') || labels.includes('breaking')) {
+              versionType = 'major';
+              detectionMethod = 'labels';
+            } else if (labels.includes('minor') || labels.includes('feature')) {
+              versionType = 'minor';
+              detectionMethod = 'labels';
+            } else if (labels.includes('patch') || labels.includes('bugfix')) {
+              versionType = 'patch';
+              detectionMethod = 'labels';
+            } else {
+              // Manual override via PR title syntax: [major], [minor], [patch]
+              const titleMatch = prTitle.match(/^\[(major|minor|patch)\]/i);
+              if (titleMatch) {
+                versionType = titleMatch[1].toLowerCase();
+                description = prTitle.replace(/^\[(major|minor|patch)\]\s*/i, '');
+                detectionMethod = 'title syntax';
+              } else {
+                // Automatic detection (much more conservative)
+                const combined = (prTitle + ' ' + prBody + ' ' + commits).toLowerCase();
 
-                      // Major: Only with very explicit breaking change indicators
-                      if ((combined.includes('breaking change') ||
-                           combined.includes('breaking:') ||
-                           combined.includes('major:') ||
-                           combined.includes('!breaking') ||
-                           (combined.includes('remove') && combined.includes('api')) ||
-                           (combined.includes('delete') && combined.includes('command')))) {
-                        versionType = 'major';
-                      }
-                      // Minor: New features, commands, enhancements
-                      else if (combined.includes('feat:') ||
-                               combined.includes('feature:') ||
-                               combined.includes('add command') ||
-                               combined.includes('new command') ||
-                               combined.includes('add feature') ||
-                               combined.includes('new feature') ||
-                               combined.includes('minor:') ||
-                               combined.includes('enhance') ||
-                               (combined.includes('add') && (combined.includes('option') || combined.includes('flag')))) {
-                        versionType = 'minor';
-                      }
-                      // Everything else defaults to patch
-                    }
-                  }
+                // Major: Only with very explicit breaking change indicators
+                if ((combined.includes('breaking change') ||
+                     combined.includes('breaking:') ||
+                     combined.includes('major:') ||
+                     combined.includes('!breaking') ||
+                     (combined.includes('remove') && combined.includes('api')) ||
+                     (combined.includes('delete') && combined.includes('command')))) {
+                  versionType = 'major';
+                }
+                // Minor: New features, commands, enhancements
+                else if (combined.includes('feat:') ||
+                         combined.includes('feature:') ||
+                         combined.includes('add command') ||
+                         combined.includes('new command') ||
+                         combined.includes('add feature') ||
+                         combined.includes('new feature') ||
+                         combined.includes('minor:') ||
+                         combined.includes('enhance') ||
+                         (combined.includes('add') && (combined.includes('option') || combined.includes('flag')))) {
+                  versionType = 'minor';
+                }
+                // Everything else defaults to patch
+                detectionMethod = 'automatic';
+              }
+            }
 
-                  // Clean up description
-                  description = description
-                    .replace(/^(feat|fix|docs|style|refactor|test|chore|perf)(\([^)]+\))?: /i, '')
-                    .replace(/^(add|fix|update|remove|delete|improve|enhance): /i, '')
-                    .replace(/^\[(major|minor|patch)\]\s*/i, '')
-                    .trim();
+            // Clean up description
+            description = description
+              .replace(/^(feat|fix|docs|style|refactor|test|chore|perf)(\([^)]+\))?: /i, '')
+              .replace(/^(add|fix|update|remove|delete|improve|enhance): /i, '')
+              .replace(/^\[(major|minor|patch)\]\s*/i, '')
+              .trim();
 
-                  if (!description || description.length < 5) {
-                    description = prTitle;
-                  }
+            if (!description || description.length < 5) {
+              description = prTitle.replace(/^\[(major|minor|patch)\]\s*/i, '').trim();
+            }
 
-                  description = description.charAt(0).toUpperCase() + description.slice(1);
+            description = description.charAt(0).toUpperCase() + description.slice(1);
 
-                  core.setOutput('version_type', versionType);
-                  core.setOutput('description', description);
+            core.setOutput('version_type', versionType);
+            core.setOutput('description', description);
 
-                  console.log(`Generated changeset: ${versionType} - ${description}`);
-                  console.log(`Detection method: ${labels.length > 0 ? 'labels' : titleMatch ? 'title syntax' : 'automatic'}`);
+            console.log(`Generated changeset: ${versionType} - ${description}`);
+            console.log(`Detection method: ${detectionMethod}`);
 
       - name: Create changeset file
         if: steps.pr-info.outputs.skip != 'true'
@@ -222,9 +228,9 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: `🤖 **Changeset Generated Automatically**
 
-              **Version Bump:** \`${versionType}\`
-              **Description:** ${description}
-              **Files Changed:** ${meaningfulFiles} meaningful files
+            **Version Bump:** \`${versionType}\`
+            **Description:** ${description}
+            **Files Changed:** ${meaningfulFiles} meaningful files
 
-              The package version has been updated and a changelog entry has been created! 🚀`
+            The package version has been updated and a changelog entry has been created! 🚀`
             });


### PR DESCRIPTION
Set a detectionMethod for changeset generation (labels, title syntax, automatic). Improve description cleanup by stripping the [major|minor|patch]
prefix when falling back, and tidy logging/templating indentation.