### PR TITLE
[minor] Add tag support for brain dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
-
+context.md
 .flux/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@
 
 - 32bce38: Revert "[minor] Flux dump/support multiline"
 
-## 1.0.0
+## 0.1.5
+
+### Minor Changes
+
+-  "[minor] Introduce child folder support for flux"
+
+## 0.1.0
 
 ### Major Changes
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,16 @@ flux init
 ```
 *Interactive setup will ask about your privacy preferences*
 
-### 2. Start capturing thoughts
+### 2. Start capturing thoughts with tags
 ```bash
+# Basic brain dumps
 flux dump "remember to add error handling to auth module"
 flux dump "bug in user validation - check line 42" 
-flux dump "idea: add dark mode toggle"
+
+# Tagged brain dumps for better organization
+flux dump -i "add dark mode toggle"              # Ideas
+flux dump -n "team meeting at 3pm tomorrow"      # Notes  
+flux dump -t "refactor payment processing logic" # Tasks
 ```
 
 ### 3. Search your brain dumps
@@ -41,22 +46,27 @@ flux dump "idea: add dark mode toggle"
 # Search with a query
 flux search "auth"
 
+# Search by tags (when implemented in search)
+flux search "ideas"
+flux search "tasks"
+
 # List recent dumps (no query)
 flux search
 ```
 
-
 ## Features
 
-### Brain Dump System
+### Brain Dump System with Smart Tags
 - Instantly capture thoughts without breaking flow: `flux dump "fix auth validation bug"`
+- **Tag system** for better organization: `-i` for ideas, `-n` for notes, `-t` for tasks
 - Git-aware context tracking (branch, working directory, uncommitted changes)
 - Monthly file organization for easy browsing
 - Privacy-first design - you control what gets tracked
 
-### Search
+### Intelligent Search
 - Fuzzy search across all your brain dumps: `flux search "auth"`
-- Configurable search fields (message, branch, working directory)
+- **Tag-aware searching** for filtering by type
+- Configurable search fields (message, branch, working directory, tags)
 - Result ranking with relevance scores
 - Multi-month search with automatic limits
 
@@ -78,41 +88,166 @@ flux search
 - No need to initialize in every subfolder - works project-wide
 - Seamlessly handles monorepos and complex project structures
 
-
 ## Commands
 
 | Command | Description | Example |
 |---------|-------------|---------|
 | `flux init` | Initialize flux-cap with privacy setup | `flux init` |
 | `flux dump <message...>` | Capture a brain dump | `flux dump "fix the bug in auth.ts"` |
+| `flux dump -i <message...>` | Capture an idea | `flux dump -i "add keyboard shortcuts"` |
+| `flux dump -n <message...>` | Capture a note | `flux dump -n "meeting notes from standup"` |
+| `flux dump -t <message...>` | Capture a task | `flux dump -t "refactor user authentication"` |
+| `flux dump -m` | Multiline input mode | `flux dump -m` |
 | `flux search [query...]` | Search brain dumps or list recent ones | `flux search "authentication"` |
-| `flux config <fields...>` | View or update configuration | `flux config` |
+| `flux config [field] [value]` | View or update configuration | `flux config search.resultLimit 20` |
+| `flux config --add-tag <tag>` | Add custom tags to configuration | `flux config --add-tag "bug"` |
+| `flux config --remove-tag <tag>` | Remove tags from configuration | `flux config --remove-tag "old-tag"` |
 | `flux reset` | Complete reset (deletes all data) | `flux reset` |
+
+## Tag System
+
+### Built-in Tags
+flux-cap comes with three built-in tag shortcuts:
+- **`-i, --ideas`** - For capturing ideas and inspiration
+- **`-n, --notes`** - For general notes and reminders  
+- **`-t, --tasks`** - For tasks and todos
+
+### Custom Tags (via config)
+Extend your tagging system by adding custom tags through configuration:
+```bash
+# Add custom tags
+flux config --add-tag "bug"
+flux config --add-tag "meeting"
+flux config --add-tag "review"
+
+# Remove tags you no longer need
+flux config --remove-tag "old-tag"
+```
+
+### Tag Examples
+```bash
+# Ideas for future features
+flux dump -i "add real-time collaboration to the editor"
+flux dump -i "implement auto-save every 30 seconds"
+
+# Meeting notes and reminders
+flux dump -n "team decided to use TypeScript for new components"
+flux dump -n "remember to update documentation before release"
+
+# Task tracking
+flux dump -t "fix memory leak in image processor"
+flux dump -t "write unit tests for authentication module"
+
+# Combine with multiline for detailed entries
+flux dump -t -m  # Opens editor for detailed task description
+```
 
 ## Use Cases
 
 ### Context Switching
 ```bash
 # Before switching tasks
-flux dump "was working on user auth, next: add validation to login form"
+flux dump -t "was working on user auth, next: add validation to login form"
 
 # After interruption  
 flux search "auth"  # Quickly find where you left off
+flux search "tasks" # Find your pending tasks
 ```
 
-### Bug Tracking
+### Bug Tracking & Ideas
 ```bash
-flux dump "weird bug in payment flow - users can't checkout"
-flux dump "bug seems related to session timeout"
+# Track bugs and investigations
+flux dump -n "weird bug in payment flow - users can't checkout"
+flux dump -n "bug seems related to session timeout - check Redis config"
+
+# Capture ideas as they come
+flux dump -i "add keyboard shortcuts to dashboard"
+flux dump -i "maybe use React.memo for performance optimization"
 
 # Later...
 flux search "payment bug"
+flux search "ideas"
 ```
 
-### Idea Capture
+### Meeting Notes & Task Management  
 ```bash
-flux dump "idea: add keyboard shortcuts to dashboard" 
-flux dump "maybe use React.memo for performance optimization"
+# Capture meeting outcomes
+flux dump -n "team standup: focus on performance this sprint"
+flux dump -t "implement caching layer for API responses"
+
+# Track follow-up tasks
+flux dump -t "review Sarah's PR for authentication changes"
+flux dump -t "update deployment documentation"
+```
+
+## Configuration
+
+flux-cap stores configuration in `.flux/config.json`. You can customize:
+
+### Privacy Settings
+```json
+{
+  "privacy": {
+    "hideWorkingDir": false,       // Hide file paths
+    "hideBranchName": false,       // Hide git branch names  
+    "hideUncommittedChanges": false // Hide git status
+  }
+}
+```
+
+### Search Configuration  
+```json
+{
+  "search": {
+    "searchFields": ["message", "branch", "workingDir", "tags"],
+    "resultLimit": 10,
+    "fuseOptions": {
+      "threshold": 0.3,            // 0.0 = exact match, 1.0 = match anything
+      "includeScore": true
+    }
+  }
+}
+```
+
+### Tag Configuration
+```json
+{
+  "tags": ["bug", "meeting", "review", "urgent"]  // Your custom tags
+}
+```
+
+### Other Options
+```json
+{
+  "defaultFocusDuration": 1500,    // 25 minutes in seconds
+  "todoKeywords": ["TODO", "FIXME", "BUG", "OPTIMIZE", "HACK"],
+  "sorted": true,                  // Sort dumps chronologically
+  "theme": "minimal"
+}
+```
+
+## Data Structure
+
+```
+.flux/
+├── config.json          # Your configuration
+├── dumps/               # Brain dumps organized by month
+│   ├── 2026-02.json     
+│   └── 2026-03.json     
+└── sessions/            # Future: Focus session tracking
+```
+
+### Brain Dump Format
+```json
+{
+  "id": "019c5419-671b-7000-9600-5d9b4c563579",
+  "timestamp": "2026-02-12T23:04:36.891Z", 
+  "message": "fix auth validation bug",
+  "tags": ["tasks"],
+  "workingDir": "/Users/you/project",
+  "branch": "feature/auth-fix", 
+  "hasUncommittedChanges": true
+}
 ```
 
 ## Automated Versioning
@@ -144,6 +279,7 @@ bun run changeset:status
 
 # Apply version changes locally
 bun run changeset:version
+```
 
 ## Development
 
@@ -162,96 +298,6 @@ bun run dev <command>
 bun run build
 npm link
 ```
-
-## Configuration
-
-flux-cap stores configuration in `.flux/config.json`. You can customize:
-
-### Privacy Settings
-```json
-{
-  "privacy": {
-    "hideWorkingDir": false,       // Hide file paths
-    "hideBranchName": false,       // Hide git branch names  
-    "hideUncommittedChanges": false // Hide git status
-  }
-}
-```
-
-### Search Configuration  
-```json
-{
-  "search": {
-    "searchFields": ["message", "branch", "workingDir"],
-    "resultLimit": 10,
-    "fuseOptions": {
-      "threshold": 0.3,            // 0.0 = exact match, 1.0 = match anything
-      "includeScore": true
-    }
-  }
-}
-```
-
-### Other Options
-```json
-{
-  "defaultFocusDuration": 1500,    // 25 minutes in seconds
-  "todoKeywords": ["TODO", "FIXME", "BUG", "OPTIMIZE", "HACK"],
-  "sorted": true,                  // Sort dumps chronologically
-  "theme": "minimal"
-}
-```
-
-## Data Structure
-
-```
-.flux/
-├── config.json          # Your configuration
-├── dumps/               # Brain dumps organized by month
-│   ├── 2026-02.json     
-│   └── 2026-03.json     
-└── sessions/            # Future: Focus session tracking
-```
-
-### Brain Dump Format
-```json
-{
-  "id": "019c5419-671b-7000-9600-5d9b4c563579",
-  "timestamp": "2026-02-12T23:04:36.891Z", 
-  "message": "fix auth validation bug",
-  "workingDir": "/Users/you/project",
-  "branch": "feature/auth-fix",
-  "hasUncommittedChanges": true
-}
-```
-
-## Use Cases
-
-### Context Switching
-```bash
-# Before switching tasks
-flux dump "was working on user auth, next: add validation to login form"
-
-# After interruption  
-flux search "auth"  # Quickly find where you left off
-```
-
-### Bug Tracking
-```bash
-flux dump "weird bug in payment flow - users can't checkout"
-flux dump "bug seems related to session timeout"
-
-# Later...
-flux search "payment bug"
-```
-
-### Idea Capture
-```bash
-flux dump "idea: add keyboard shortcuts to dashboard"
-flux dump "maybe use React.memo for performance optimization"
-```
-
-## Development
 
 Built with:
 - **Bun** - Fast JavaScript runtime
@@ -276,6 +322,7 @@ src/
 ## Roadmap
 
 ### Phase 2 (Coming Soon)
+- [ ] Enhanced tag-based search filtering
 - [ ] ASCII Pomodoro timer with themes
 - [ ] Visual focus mode display
 - [ ] Theme rotation system
@@ -284,11 +331,13 @@ src/
 - [ ] Advanced git context switching
 - [ ] Session restoration
 - [ ] Time tracking per context
+- [ ] Tag analytics and insights
 
 ### Phase 4 (Maybe)
 - [ ] AI-powered brain dump analysis
 - [ ] Team collaboration features
 - [ ] Cross-machine sync
+- [ ] Smart tag suggestions
 
 ## Contributing
 

--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -1,19 +1,38 @@
-import { getConfigFile } from "../utils/lib";
+import { FLUX_CONFIG_PATH } from "../utils";
+import { getConfigFile, getFluxPath } from "../utils/lib";
 
-// TODO: Still to be implemented
-export async function configCommand(fields: string[]) {
-	console.log("This command is still to be implemented");
+export async function configCommand(options: { a?: string, r?: string }, tag: string[]) {
+
+	const fluxPath = await getFluxPath()
 	const fs = await import("fs");
-	const config = await getConfigFile();
+	const config = await getConfigFile(fluxPath);
 
-	const value = fields[fields.length - 1];
-	const keys = fields.slice(0, -1)[0]?.split('.').map(k => k.trim()) || [];
 
-	console.log(`want to update config field: ${JSON.stringify(keys)} with value: ${value}`);
+	if (options.a) {
+		console.log("Adding tag(s) to configuration...");
+		if (!config.tags) {
+			config.tags = [];
+		}
+		if (!config.tags.includes(options.a)) {
+			config.tags = Array.from(new Set([...config.tags, ...options.a]))
+			console.log(config.tags)
+			fs.writeFileSync(fluxPath + FLUX_CONFIG_PATH, JSON.stringify(config, null, 4));
+			console.log(`Tag "${options.a}" added to configuration.`);
+		} else {
+			console.log(`Tag "${options.a}" already exists in configuration.`);
+		}
+	}
 
-	if (keys.length === 0 || value === undefined) {
-		console.log("Current Flux Capacitor configuration:");
-		console.log(JSON.stringify(config, null, 4));
-		return;
+	if (options.r) {
+		console.log("Removing tag(s) from configuration...");
+		for (const removeTag of options.r) {
+			if (config.tags && config.tags.includes(removeTag)) {
+				config.tags = config.tags.filter(tag => tag !== removeTag);
+				fs.writeFileSync(fluxPath + FLUX_CONFIG_PATH, JSON.stringify(config, null, 4));
+				console.log(`Tag "${removeTag}" removed from configuration.`);
+			} else {
+				console.log(`Tag "${removeTag}" does not exist in configuration.`);
+			}
+		}
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,9 @@ program.command('reset')
 
 program.command('dump [message...]')
 	.option('-m, --multiline', 'Enable multiline input mode')
+	.option('-n, --notes', 'Jot down a note')
+	.option('-i, --ideas', 'Jot down an idea')
+	.option('-t, --tasks', 'Jot down a task')
 	.description('Add a brain dump with a message. Use --multiline for multi-line input.')
 	.action(async (message, options) => {
 		await handleBrainDump(message, options);
@@ -32,8 +35,10 @@ program.command('search [query...]')
 	.action((query?: string[]) => {
 		searchBrainDumpCommand(query ? query : [""]);
 	})
-
-program.command('config <fields...>')
+// .alias("cfg")
+program.command('config ')
+	.option("-r [tag...], --remove-tag [tag...]", "Remove a tag from the configuration")
+	.option("-a [tag...], --add-tag [tag...]", "Add a tag to the configuration")
 	.description('Update configuration fields. Example: flux config search.limit 10')
 	.action(configCommand)
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,9 @@ export type FluxConfig = {
 			threshold: number,
 			includeScore: boolean
 		}
-	}
+	},
+	// ALL optional fields below this line - 24/02/26 - v0.3.0
+	tags?: string[];
 };
 
 export type BrainDump = {
@@ -26,6 +28,14 @@ export type BrainDump = {
 	message: string;
 	workingDir?: string;
 	branch?: string | null;
-	tags?: [],
+	tags?: string[],
 	hasUncommittedChanges?: boolean;
+}
+
+
+export type BrainDumpOptions = {
+	multiline?: boolean;
+	notes?: boolean;
+	ideas?: boolean;
+	tasks?: boolean;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,5 @@
+import packageJson from "../../package.json"
+
 import type { FluxConfig } from "../types";
 
 export const FLUX_FOLDER_PATH = ".flux/";
@@ -9,7 +11,7 @@ export const FLUX_SESSION_PATH = `${FLUX_FOLDER_PATH}sessions/`;
 export const FLUX_CONFIG_PATH = `${FLUX_FOLDER_PATH}config.json`;
 
 export const FLUX_DEFAULT_CONFIG: FluxConfig = {
-	fluxVersion: "0.0.1",
+	fluxVersion: packageJson.version,
 	defaultFocusDuration: 1500, // 25 minutes
 	todoKeywords: ["TODO", "FIXME", "BUG", "OPTIMIZE", "HACK"],
 	notifications: true,
@@ -27,7 +29,8 @@ export const FLUX_DEFAULT_CONFIG: FluxConfig = {
 			threshold: 0.3,
 			includeScore: true
 		}
-	}
+	},
+	tags: ["notes", "ideas", "tasks"],
 };
 
 export const FLUX_DEFAULT_BRAIN_DUMP_CONTENT = {

--- a/src/utils/privacy.ts
+++ b/src/utils/privacy.ts
@@ -1,4 +1,4 @@
-import type { FluxConfig } from "../types";
+import type { BrainDumpOptions, FluxConfig } from "../types";
 import { execSync } from 'child_process';
 
 export function getGitUncommittedChanges(config: FluxConfig): boolean {
@@ -32,4 +32,25 @@ export function getCurrentBranch(config: FluxConfig): string | null {
 	} catch (error) {
 		return "";
 	}
+}
+
+export function getTags(options: BrainDumpOptions, config: FluxConfig) {
+
+	let tags: string[] = [];
+	let optionTags = Object.keys(options).filter(key => options[key as keyof BrainDumpOptions] === true);
+
+	if (!config.tags) {
+		console.log("You do not have any tags configured. You can add tags to your config to use this feature. or run `flux config --add-tags notes ideas tasks` to add default tags. or update the config file");
+	} else {
+
+		for (const tag of optionTags) {
+			if (config.tags && config.tags.includes(tag)) {
+				tags.push(tag);
+			}
+		}
+	}
+
+	return tags;
+
+
 }


### PR DESCRIPTION
Add CLI flags (-i, -n, -t), implement tag parsing (getTags), persist tags on brain dump entries, and expose config commands to add/remove tags. Update default config, types, README, and changelog to document tagging features