### PR TITLE
Add Rezi-based TUI and optional search filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Want to contribute or run locally?
 
 ```bash
 # Clone and setup
-git clone https://github.com/yourusername/flux-cap
+git clone https://github.com/kaustubh285/flux-cap
 cd flux-cap
 bun install
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "flux-cap",
       "dependencies": {
+        "@rezi-ui/core": "^0.1.0-alpha.59",
+        "@rezi-ui/jsx": "^0.1.0-alpha.59",
+        "@rezi-ui/node": "^0.1.0-alpha.59",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "commander": "^14.0.3",
@@ -122,6 +125,14 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@rezi-ui/core": ["@rezi-ui/core@0.1.0-alpha.59", "", {}, "sha512-2hDGLQouRI2LBBqU4IjpRWw931v7brFo0r/JnOvD8LCHoSk5aYt/B06O2kiE5ZbDz84EzAOY3QUzcyOYf1xxEg=="],
+
+    "@rezi-ui/jsx": ["@rezi-ui/jsx@0.1.0-alpha.59", "", { "dependencies": { "@rezi-ui/core": "0.1.0-alpha.59" } }, "sha512-Tc/JsPEuPJxGwh0EB6KRPEt0dTwk4YYFsT2F/qgxPqnvPXUqJoTdHRBtfkHKZdx/fKazWaO9HP3sw4X40XcfZQ=="],
+
+    "@rezi-ui/native": ["@rezi-ui/native@0.1.0-alpha.59", "", {}, "sha512-dSz92BT2NQnKQi3fZi5Zx8+A9duzU9lePPyxV0xaEVRK8wHvk3HLkUYWSEAbQlMsn3zuk0tFnWxY9Re9ID4fOQ=="],
+
+    "@rezi-ui/node": ["@rezi-ui/node@0.1.0-alpha.59", "", { "dependencies": { "@rezi-ui/core": "0.1.0-alpha.59", "@rezi-ui/native": "0.1.0-alpha.59" } }, "sha512-xDjfAeEl48Tw6VbrAeKxVFNet9Wq4iRdZlW0PlcTl0IYOVVcFsI24yIv3xrTon9gL1yiYuKci+kn12HW3Sskig=="],
 
     "@types/inquirer": ["@types/inquirer@9.0.9", "", { "dependencies": { "@types/through": "*", "rxjs": "^7.2.0" } }, "sha512-/mWx5136gts2Z2e5izdoRCo46lPp5TMs9R15GTSsgg/XnZyxDWVqoVU3R9lWnccKpqwsJLvRoxbCjoJtZB7DSw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,64 +1,67 @@
 {
-    "name": "@dev_desh/flux-cap",
-    "type": "module",
-    "version": "0.9.1",
-    "description": "Git-aware CLI context manager for ADHD developers",
-    "bin": {
-        "flux": "./dist/index.js"
-    },
-    "files": [
-        "dist/**/*",
-        "README.md",
-        "LICENSE"
-    ],
-    "scripts": {
-        "build": "bun build src/index.ts --outdir dist --target node --format esm",
-        "dev": "bun run src/index.ts",
-        "prepublishOnly": "bun run build",
-        "publish": "npm publish --access=public",
-        "local-install": "bun run build && npm link",
-        "local-uninstall": "npm unlink -g flux-cap",
-        "local-reinstall": "bun run local-uninstall && bun run local-install",
-        "changeset": "changeset",
-        "changeset:add": "changeset add",
-        "changeset:status": "changeset status",
-        "changeset:version": "changeset version",
-        "changeset:publish": "changeset publish",
-        "format": "bunx --bun @biomejs/biome check --write"
-    },
-    "engines": {
-        "node": ">=18.0.0"
-    },
-    "keywords": [
-        "cli",
-        "productivity",
-        "adhd",
-        "git",
-        "context-switching",
-        "brain-dump",
-        "developer-tools"
-    ],
-    "dependencies": {
-        "@types/react": "^19.2.14",
-        "@types/react-dom": "^19.2.3",
-        "commander": "^14.0.3",
-        "fuse.js": "^7.1.0",
-        "ink": "^6.8.0",
-        "ink-text-input": "^6.0.0",
-        "inquirer": "^13.2.5",
-        "react": "^19.2.4",
-        "react-devtools-core": "^7.0.1",
-        "react-dom": "^19.2.4"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "2.4.4",
-        "@changesets/cli": "^2.29.8",
-        "@types/inquirer": "^9.0.9",
-        "@types/node": "^25.3.3"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/kaustubh285/flux-cap"
-    },
-    "license": "MIT"
+	"name": "@dev_desh/flux-cap",
+	"type": "module",
+	"version": "0.9.1",
+	"description": "Git-aware CLI context manager for ADHD developers",
+	"bin": {
+		"flux": "./dist/index.js"
+	},
+	"files": [
+		"dist/**/*",
+		"README.md",
+		"LICENSE"
+	],
+	"scripts": {
+		"build": "bun build src/index.ts --outdir dist --target node --format esm --external @rezi-ui/core --external @rezi-ui/node --external @rezi-ui/jsx --external @rezi-ui/native",
+		"dev": "bun run src/index.ts",
+		"prepublishOnly": "bun run build",
+		"publish": "npm publish --access=public",
+		"local-install": "bun run build && npm link",
+		"local-uninstall": "npm unlink -g flux-cap",
+		"local-reinstall": "bun run local-uninstall && bun run local-install",
+		"changeset": "changeset",
+		"changeset:add": "changeset add",
+		"changeset:status": "changeset status",
+		"changeset:version": "changeset version",
+		"changeset:publish": "changeset publish",
+		"format": "bunx --bun @biomejs/biome check --write"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"keywords": [
+		"cli",
+		"productivity",
+		"adhd",
+		"git",
+		"context-switching",
+		"brain-dump",
+		"developer-tools"
+	],
+	"dependencies": {
+		"@rezi-ui/core": "^0.1.0-alpha.59",
+		"@rezi-ui/jsx": "^0.1.0-alpha.59",
+		"@rezi-ui/node": "^0.1.0-alpha.59",
+		"@types/react": "^19.2.14",
+		"@types/react-dom": "^19.2.3",
+		"commander": "^14.0.3",
+		"fuse.js": "^7.1.0",
+		"ink": "^6.8.0",
+		"ink-text-input": "^6.0.0",
+		"inquirer": "^13.2.5",
+		"react": "^19.2.4",
+		"react-devtools-core": "^7.0.1",
+		"react-dom": "^19.2.4"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.4",
+		"@changesets/cli": "^2.29.8",
+		"@types/inquirer": "^9.0.9",
+		"@types/node": "^25.3.3"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/kaustubh285/flux-cap"
+	},
+	"license": "MIT"
 }

--- a/src/commands/search.command.ts
+++ b/src/commands/search.command.ts
@@ -13,7 +13,7 @@ import {
 import { createFuseInstance } from "../utils/fuse.instance";
 import { searchV2Helper } from "@/utils/search/helper";
 
-export async function searchBrainDumpCommand(query: string[], returnResults: boolean = false) {
+export async function searchBrainDumpCommand(query: string[], returnResults: boolean = false, searchResultLimit?: number, specificListOfFiles: string[] | null = null) {
 	if (!returnResults) console.log("Searching all brain dumps...");
 	const fluxPath = await getFluxPath();
 	const config = await getConfigFile(fluxPath);
@@ -28,7 +28,7 @@ export async function searchBrainDumpCommand(query: string[], returnResults: boo
 			final: Number;
 		}
 	}> = [];
-	const allFilePaths = await getAllBrainDumpFilePaths(fluxPath);
+	const allFilePaths = specificListOfFiles ? specificListOfFiles : await getAllBrainDumpFilePaths(fluxPath);
 
 	if (combinedQuery) {
 		for (const searchQuery of query) {
@@ -73,7 +73,7 @@ export async function searchBrainDumpCommand(query: string[], returnResults: boo
 		});
 	}
 
-	const resultLimit = config?.search?.resultLimit || (combinedQuery ? 10 : 5);
+	const resultLimit = searchResultLimit ? searchResultLimit : config?.search?.resultLimit || (combinedQuery ? 10 : 5);
 	const limitedResults = searchResults.slice(0, resultLimit);
 
 	if (returnResults) {

--- a/src/commands/ui.command.ts
+++ b/src/commands/ui.command.ts
@@ -1,8 +1,15 @@
 import React from 'react';
 import { render } from 'ink';
 import { SearchApp } from '../components/search.components';
+import { FluxTui } from '@/components/search.rezi';
 
-export async function tuiCommand() {
+export async function tuiCommandRezi() {
+	console.log('\n Starting Flux-Cap Interactive Search...\n');
+	// render(React.createElement(SearchApp));
+	await FluxTui()
+}
+
+export async function tuiCommandInk() {
 	console.log('\n Starting Flux-Cap Interactive Search...\n');
 	render(React.createElement(SearchApp));
 }

--- a/src/components/search.rezi.tsx
+++ b/src/components/search.rezi.tsx
@@ -1,0 +1,304 @@
+/** @jsxImportSource @rezi-ui/jsx */
+import { createNodeApp } from "@rezi-ui/node";
+import { Column, Row, Text, Input, Button, Box, Divider, Table, Page } from "@rezi-ui/jsx";
+import { searchBrainDumpCommand } from "@/commands/search.command";
+import { getAllBrainDumpFilePaths, getFluxPath, getTimeAgo } from "@/utils";
+import type { SearchResult } from "@/types";
+import { darkTheme, draculaTheme, nordTheme, rgb } from "@rezi-ui/core";
+
+type AppState = {
+	query: string;
+	results: SearchResult[];
+	selectedIndex: number;
+	loading: boolean;
+	availableFiles: string[];
+	// selectedId?: string | null;
+	selectedFile: string | null;
+};
+
+export const FluxTui = async () => {
+	const fluxPath = await getFluxPath();
+	const allFiles = await getAllBrainDumpFilePaths(fluxPath);
+	const fileNames = allFiles
+		.map(p => p.match(/(\d{4}-\d{2})\.json$/)?.[1] ?? null)
+		.filter((f): f is string => f !== null)
+		.sort()
+		.reverse();
+
+	const app = createNodeApp<AppState>({
+		initialState: {
+			query: '',
+			results: [],
+			selectedIndex: 0,
+			loading: false,
+			availableFiles: fileNames,
+			// selectedId: null;
+			selectedFile: "all",
+		},
+		theme: draculaTheme,
+	});
+
+	const loadDumps = async (query?: string, selectedFile?: string) => {
+		app.update(prev => ({ ...prev, loading: true }));
+		const specificFiles = (selectedFile && selectedFile !== "all") ? [allFiles.find(f => f.endsWith(`${selectedFile}.json`))!] : null;
+		try {
+			const raw = query?.trim()
+				? await searchBrainDumpCommand(query.split(' '), true, 15, specificFiles)
+				: await searchBrainDumpCommand([], true, 20, specificFiles);
+			app.update(prev => ({
+				...prev,
+				results: (raw as SearchResult[]) || [],
+				loading: false,
+				selectedIndex: 0,
+			}));
+		} catch {
+			app.update(prev => ({ ...prev, results: [], loading: false }));
+		}
+	};
+
+	await loadDumps();
+
+	const getContextTags = (result: SearchResult): string => {
+		const tags: string[] = [];
+		if (result.scores) {
+			if (result.scores.recency > 0.8) tags.push('recent');
+			if (result.scores.gitContext >= 1.0) tags.push('branch');
+			if (result.scores.gitContext >= 1.5) tags.push('dir');
+		}
+		if (result.item.tags?.length) tags.push(...result.item.tags);
+		return tags.join(', ');
+	};
+
+	app.view((state) => {
+		const selected = state.results[state.selectedIndex] ?? null;
+
+		return (
+			<Page
+				header={
+					<Row gap={2} p={1}>
+						<Text variant="label" style={{ bold: true }}>flux</Text>
+						<Text variant="caption" style={{ dim: true }}>·</Text>
+						<Row gap={0}>
+							<Text variant="label">Search {state.query && `[searching for:`}</Text> <Text style={{
+								fg: rgb(200, 100, 200),
+								underline: true,
+								bold: true,
+								italic: true,
+							}}>{state.query}</Text>
+							{state.query && `]`}
+						</Row>
+						<Box flex={1} border="none" />
+						<Text variant="caption" style={{ dim: true }}>
+							{state.loading ? 'searching...' : `${state.results.length} results`}
+						</Text>
+					</Row>
+				}
+				body={
+					<Row flex={1} gap={0}>
+						<Column flex={1} gap={0}>
+							<Table
+								id="results-table"
+								columns={[
+									// { key: "index", header: "#", width: 0 },
+									// { key: "id", header: "ID", width: 0 },
+									// { key: "score", header: "Score", width: 0 },
+									{ key: "time", header: "Time", width: 10 },
+									{ key: "message", header: "Message", flex: 1, overflow: "ellipsis" },
+									// { key: "tags", header: "Tags", width: 22, overflow: "ellipsis" },
+								]}
+								onRowPress={(value) => {
+									const index = state.results.findIndex(r => `#${r.item.id.substring(0, 8)}` === value.id);
+									if (index !== -1) {
+										app.update(prev => ({ ...prev, selectedIndex: index }));
+									}
+								}}
+								data={state.results.map((result, index) => ({
+									index: String(index + 1),
+									id: `#${result.item.id.substring(0, 8)}`,
+									score: result.scores?.final?.toFixed(2) ?? '0.00',
+									time: getTimeAgo(new Date(result.item.timestamp)).replace(" ago", ""),
+									message: result.item.message ?? '',
+									// tags: getContextTags(result),
+								}))}
+								stripedRows={true}
+								// stripeStyle={{
+								// 	odd: rgb(40, 42, 54),
+								// 	even: rgb(68, 71, 90)
+								// }}
+								getRowKey={(_row, index) => `row-${index}`}
+								selectionMode="single"
+								selection={[`row-${state.selectedIndex}`]}
+								borderStyle={{ variant: "rounded" }}
+							/>
+						</Column>
+
+						<Column flex={2} gap={1} p={2} scrollY={100}>
+							{selected && (
+								<Row>
+									<Row gap={2} flex={1}>
+										<Text variant="caption" style={{ dim: true }}>ID</Text>
+										<Text style={{
+											underline: true,
+											fg: rgb(200, 0, 200)
+										}}>#{selected.item.id.substring(0, 8)}</Text>
+									</Row>
+									<Column gap={0}>
+										<Row gap={2}>
+											<Text variant="caption" style={{ dim: true }}>Created</Text>
+											<Text>{new Date(selected.item.timestamp).toLocaleString()}</Text>
+										</Row>
+										{selected.item.branch && (
+											<Row gap={2}>
+												<Text variant="caption" style={{ dim: true }}>Branch</Text>
+												<Text style={{
+													fg: rgb(200, 200, 25)
+												}}>
+													{selected.item.branch}
+													{selected.item.hasUncommittedChanges ? ' (uncommitted)' : ''}
+												</Text>
+											</Row>
+										)}
+										{selected.item.workingDir && <Row gap={2}>
+											<Text variant="caption" style={{ dim: true }}>Dir</Text>
+											<Text >{(() => {
+												const parts = selected.item.workingDir?.split("/") || [];
+												return parts.length >= 2
+													? `${parts[parts.length - 2]} / ${parts[parts.length - 1]}`
+													: selected.item.workingDir || '';
+											})()}</Text>
+										</Row>}
+									</Column>
+								</Row>
+							)}
+							<Divider />
+							{selected ? (
+								<Column gap={1}>
+									<Column gap={0} wrap>
+										<Text variant="caption" style={{ dim: true }}>Message:</Text>
+										<Text wrap={true}>{selected.item.message}</Text>
+									</Column>
+
+
+									{selected.scores && (
+										<Column gap={0}>
+											<Text variant="caption" style={{ dim: true }}>Context Rating: </Text>
+											<Row gap={1}>
+												<Column gap={0}>
+													<Text variant="caption" style={{ dim: true }}>final</Text>
+													<Text>{(selected.scores.final * 100).toFixed(0)}%</Text>
+												</Column>
+												<Column gap={0}>
+													<Text variant="caption" style={{ dim: true }}>fuzzy</Text>
+													<Text>{(selected.scores.fuzzyMatch * 100).toFixed(0)}%</Text>
+												</Column>
+												<Column gap={0}>
+													<Text variant="caption" style={{ dim: true }}>recency</Text>
+													<Text>{(selected.scores.recency * 100).toFixed(0)}%</Text>
+												</Column>
+												<Column gap={0}>
+													<Text variant="caption" style={{ dim: true }}>git</Text>
+													<Text>{(selected.scores.gitContext * 100).toFixed(0)}%</Text>
+												</Column>
+											</Row>
+										</Column>
+									)}
+								</Column>
+							) : (
+								<Text variant="caption" style={{ dim: true }}>
+									Use j / k or ↑ ↓ to select a dump
+								</Text>
+							)}
+						</Column>
+					</Row>
+				}
+				footer={
+					<Column gap={0}>
+						<Divider />
+						<Row gap={2} p={1} items="center">
+							<Button
+								id={`file-all`}
+								label={"all"}
+								dsVariant={state.selectedFile === "all" ? "solid" : "ghost"}
+								dsTone={state.selectedFile === "all" ? "primary" : "default"}
+								dsSize="sm"
+								onPress={() => {
+									loadDumps("", "all");
+									app.update(prev => ({
+										...prev,
+										selectedFile: prev.selectedFile === "all" ? null : "all"
+									}))
+								}}
+
+							/>
+							{state.availableFiles.slice(0, 5).map(file => (
+
+								<Button
+									key={file}
+									id={`file-${file}`}
+									label={file}
+									dsVariant={state.selectedFile === file ? "solid" : "ghost"}
+									dsTone={state.selectedFile === file ? "primary" : "default"}
+									dsSize="sm"
+									onPress={() => {
+										loadDumps("", file);
+										app.update(prev => ({
+											...prev,
+											selectedFile: prev.selectedFile === file ? null : file
+										}))
+									}}
+
+								/>
+							))}
+							{/*<Box flex={1} />*/}
+							<Text variant="caption" style={{ dim: true }}>j/k navigate · q quit</Text>
+						</Row>
+						<Row gap={1} p={1} items="center">
+							<Text variant="caption" style={{ dim: true }}>Search:</Text>
+							<Box width={"full"} flex={1}>
+								<Input
+									focusable={true}
+									style={{
+										blink: true,
+									}}
+									focusConfig={
+										{ indicator: "bracket", ringVariant: "dotted", animation: "pulse" }
+									}
+									dsSize="lg"
+									id="search"
+									value={state.query}
+									placeholder="type to search using ..."
+									onInput={(value) => {
+										app.update(prev => ({ ...prev, query: value }));
+										loadDumps(value);
+									}}
+								/>
+							</Box>
+						</Row>
+					</Column>
+				}
+			/>
+		);
+	});
+
+	app.keys({
+		'q': () => app.stop(),
+		'j': () => app.update(prev => ({
+			...prev,
+			selectedIndex: Math.min(prev.results.length - 1, prev.selectedIndex + 1),
+		})),
+		'k': () => app.update(prev => ({
+			...prev,
+			selectedIndex: Math.max(0, prev.selectedIndex - 1),
+		})),
+		'down': () => app.update(prev => ({
+			...prev,
+			selectedIndex: Math.min(prev.results.length - 1, prev.selectedIndex + 1),
+		})),
+		'up': () => app.update(prev => ({
+			...prev,
+			selectedIndex: Math.max(0, prev.selectedIndex - 1),
+		})),
+	});
+
+	await app.start();
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { initFluxCommand, resetFluxCommand } from "./commands/init.command";
 import { searchBrainDumpCommand } from "./commands/search.command";
 import { getFluxPath } from "./utils";
 import { searchV2Command } from "./commands/search.v2.command";
-import { tuiCommand } from "./commands/ui.command";
+import { tuiCommandInk, tuiCommandRezi } from "./commands/ui.command";
 const program = new Command();
 
 program
@@ -69,7 +69,12 @@ program
 program
 	.command("u")
 	.alias("ui")
-	.description("Open interactive search TUI")
-	.action(tuiCommand);
+	.description("Open interactive search TUI built using rezi")
+	.action(tuiCommandRezi);
+
+program
+	.command("ui-ink")
+	.description("Open interactive search TUI built using ink")
+	.action(tuiCommandInk);
 
 program.parse(process.argv);

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -148,7 +148,11 @@ export function getTimeAgo(date: Date): string {
 	if (diffHours < 24) return `${diffHours}h ago`;
 	if (diffDays < 7) return `${diffDays}d ago`;
 
-	return date.toLocaleDateString();
+	return date.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+	}
+	);
 }
 
 export const getContextTags = (result: SearchResult): string[] => {


### PR DESCRIPTION
Add a Rezi UI (src/components/search.rezi.tsx) and make it the default "u" command;
add a "ui-ink" command to run the existing Ink TUI. Extend searchBrainDumpCommand to
accept a result limit and an optional list of specific files. Update package.json and
bun.lock to include @rezi-ui packages and mark them external for the build. Tweak
getTimeAgo locale formatting and update README clone URL.